### PR TITLE
fix BSML title logo navigation links in subdirectory pages

### DIFF
--- a/event-pages/brightdale.html
+++ b/event-pages/brightdale.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/computing-power.html
+++ b/event-pages/computing-power.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/isml.html
+++ b/event-pages/isml.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/launch-event.html
+++ b/event-pages/launch-event.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/tech-research.html
+++ b/event-pages/tech-research.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/tomas.html
+++ b/event-pages/tomas.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/event-pages/year-kickoff.html
+++ b/event-pages/year-kickoff.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/hackathon-pages/escape-the-challenge.html
+++ b/hackathon-pages/escape-the-challenge.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/hackathon-pages/milan-hackathon.html
+++ b/hackathon-pages/milan-hackathon.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/ai-alzheimers.html
+++ b/project-pages/ai-alzheimers.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/bocconi-chatbot.html
+++ b/project-pages/bocconi-chatbot.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/ditigal-symbiosis.html
+++ b/project-pages/ditigal-symbiosis.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/gender-bias.html
+++ b/project-pages/gender-bias.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/pneumonia.html
+++ b/project-pages/pneumonia.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/reinforcement-learning.html
+++ b/project-pages/reinforcement-learning.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/solar-energy-estimation.html
+++ b/project-pages/solar-energy-estimation.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>

--- a/project-pages/spatial-heterogeneity.html
+++ b/project-pages/spatial-heterogeneity.html
@@ -41,7 +41,7 @@
     <header id="header" class="header d-flex align-items-center sticky-top">
         <div class="container-fluid position-relative d-flex align-items-center justify-content-between">
     
-          <a href="index.html" class="logo d-flex align-items-center me-auto me-xl-0">
+          <a href="../index.html" class="logo d-flex align-items-center me-auto me-xl-0">
             <!-- Uncomment the line below if you also wish to use an image logo -->
             <!-- <img src="assets/img/logo.png" alt=""> -->
             <h1 class="sitename">BSML</h1>


### PR DESCRIPTION
## Bug Fix (VSCode in treno)

The BSML title logo link was causing 404 errors when clicked. This happened because pages in subdirectories (like `project-pages/`, `event-pages/`, `hackathon-pages/`) were using `href="index.html"` instead of the correct relative path `href="../index.html"`.