### PR TITLE
fix: add missing links to people and organizations in events and hackathons

### DIFF
--- a/_events/1.md
+++ b/_events/1.md
@@ -7,7 +7,7 @@ location: "Room N07, Velodromo Building"
 
 During our last event co-organized with <a class="text-link" href="https://hephaestusai.eu/">Hephaestus AI</a>, we brought together legal, technical, and academic perspectives to explore how tech research becomes real-world technology—and how regulation and ethics shape that journey.
 
-A huge thank you to our speakers <u>Guenda Sciancalepore</u> (Cloud Solution Architect at Microsoft) and <u>Veronica M. Pruinelli</u> (lawyer specialized in AI regulation). We discussed:
+A huge thank you to our speakers [Guenda Sciancalepore](https://www.linkedin.com/in/guenda-sciancalepore/) (Cloud Solution Architect at Microsoft) and [Veronica M. Pruinelli](https://www.linkedin.com/in/veronica-m-pruinelli-a12b1b114/) (lawyer specialized in AI regulation). We discussed:
 
 - How research teams work and deliver impact  
 - How to translate AI ideas into AI products  

--- a/_events/3.md
+++ b/_events/3.md
@@ -8,11 +8,11 @@ Wow, what a wonderful BSML first ever internal event!
 
 We finally had the **Presentation Aperitivo** with our new members. It was wonderful to meet everyone and connect those minds.
 
-Our **Head of Production**, *Giacomo Cirò*, illustrated the story of how our founders came up with and conceived the idea of this association, and what it took to finally begin this journey together. He then shared our goals and all the activities we have in mind and want to pursue in the future, introducing the project he's going to lead.
+Our **Head of Production**, [Giacomo Cirò](https://www.linkedin.com/in/giacomo-ciro/), illustrated the story of how our founders came up with and conceived the idea of this association, and what it took to finally begin this journey together. He then shared our goals and all the activities we have in mind and want to pursue in the future, introducing the project he's going to lead.
 
-Our **President**, *Giulio Caputi*, showcased his experience at **Amazon** to give our members an insight into how Machine Learning is used in tech companies to solve real business problems, and how he used it to tune Database Management Systems.
+Our **President**, [Giulio Caputi](https://www.linkedin.com/in/giulio-caputi/), showcased his experience at **Amazon** to give our members an insight into how Machine Learning is used in tech companies to solve real business problems, and how he used it to tune Database Management Systems.
 
-Our **Head of Research**, *Alessandro Morosini*, presented the other projects we are going to pursue this semester, explaining how research is carried out inside BSML. Eventually, he announced the first challenge we are going to host and the prize.
+Our **Head of Research**, [Alessandro Morosini](https://www.linkedin.com/in/alessandro-morosini), presented the other projects we are going to pursue this semester, explaining how research is carried out inside BSML. Eventually, he announced the first challenge we are going to host and the prize.
 
 <br>
 <div class="col-lg-12 d-flex justify-content-center event-gallery">

--- a/_events/4.md
+++ b/_events/4.md
@@ -7,7 +7,7 @@ location: "Room 14, Sarfatti Building"
 
 Recently, OpenAI announced **Operator**, the first AI agentic model that can complete real tasks on the Internet for its users, like ordering groceries and booking a flight. AI agents are the next frontier of AI products. They are models that can actively engage with their environment, make decisions, and execute complex tasks autonomously.
 
-After graduating from Columbia University, *Thomas Mecattaf* founded *Leger Labs*, a VC-backed AI company that helps organisations build private AI agents. He also decided to pursue a PhD in Business Administration and Management at Bocconi University to enhance his skills as a technology entrepreneur.
+After graduating from Columbia University, [Thomas Mecattaf](https://www.linkedin.com/in/thomas-mecattaf/) founded [Leger Labs](https://www.leger.run/), a VC-backed AI company that helps organisations build private AI agents. He also decided to pursue a PhD in Business Administration and Management at Bocconi University to enhance his skills as a technology entrepreneur.
 
 Thomas is conducting deep industry research on AI agents to understand their capabilities, and he gave us a comprehensive overview on this topic from real-world case studies to ethical considerations, and the impact on jobs, industry and the entire economy. We explored:
 

--- a/_events/5.md
+++ b/_events/5.md
@@ -7,7 +7,7 @@ location: "Porter House Milano"
 
 Projects kick-start your career. Yet, no one teaches you how to choose what projects to pursue and, most importantly, how to find your why.
 
-*Andrea Parodi* (Bending Spoons) and *Lucabrando Sanfilippo* (Techno-Humanist) are founders of [Brightdale](https://brightdale.com), an education-oriented start-up that aims at increasing students’ “surface area of luck”.
+[Andrea Parodi](https://www.linkedin.com/in/andrea-parodi95/) (Bending Spoons) and [Lucabrando Sanfilippo](https://www.linkedin.com/in/lucabrandosanfilippo/) (Techno-Humanist) are founders of [Brightdale](https://brightdale.co), an education-oriented start-up that aims at increasing students' "surface area of luck".
 
 After years of experience in tech start-ups and companies, from San Francisco to Berlin, they want to mentor the next generation of talent.
 

--- a/_events/6.md
+++ b/_events/6.md
@@ -9,7 +9,7 @@ ChatGPT and large language models (LLMs) have transformed how we work. In partic
 
 However, current LLMs fail to understand the cause-effect relationships of the real world. This makes them inadequate for situations that require higher-level thinking, such as decision making under uncertainty.
 
-The *ION Management Science Lab (IMSL)* from *SDA Bocconi* addresses this challenge in the context of business strategy. They research decision making frameworks and develop tools with LLMs and AI agents that allow entrepreneurs to generate, simulate, and test new business theories of value.
+The [ION Management Science Lab (IMSL)](https://www.sdabocconi.it/en/faculty-research/research/innovation-and-transition-knowledge-platform/ion-management-science-lab) from [SDA Bocconi](https://www.sdabocconi.it/en/home) addresses this challenge in the context of business strategy. They research decision making frameworks and develop tools with LLMs and AI agents that allow entrepreneurs to generate, simulate, and test new business theories of value.
 
 We discussed a wide range of topics, including:
 
@@ -19,7 +19,7 @@ We discussed a wide range of topics, including:
 - AI Agents – the future of AI products, with LLMs as commodities  
 - Internship opportunities at IMSL  
 
-Many thanks to *Saeid Kazemi*, *Claudia Frosi*, and *Abhinav Pandey* for the inspiring presentation. It was a pleasure hosting you and we look forward to future collaborations.
+Many thanks to [Saeid Kazemi](https://www.linkedin.com/in/skazemi2022/), [Claudia Frosi](https://www.linkedin.com/in/claudia-frosi-11518b7a/), and [Abhinav Pandey](https://www.linkedin.com/in/abhinavpandey0009/) for the inspiring presentation. It was a pleasure hosting you and we look forward to future collaborations.
 
 <br>
 <div class="col-lg-12 d-flex justify-content-center event-gallery">

--- a/_hackathons/escape-the-challenge.md
+++ b/_hackathons/escape-the-challenge.md
@@ -6,9 +6,9 @@ date: 2025-02-20
 end_date: 2025-06-16
 ---
 
-**Escape The Challenge** is a semester-long Data Science and Entrepreneurship competition co-organized with *theHackLab Bocconi Students*.
+**Escape The Challenge** is a semester-long Data Science and Entrepreneurship competition co-organized with [theHackLab Bocconi Students](https://thehacklab.org/).
 
-Participants presented their solutions to judges from *BCG X* and *Bocconi for Innovation (B4i)*, gaining valuable feedback and insights.
+Participants presented their solutions to judges from [BCG X](https://www.bcg.com/x/) and [Bocconi for Innovation (B4i)](https://www.b4i.unibocconi.it/), gaining valuable feedback and insights.
 
 Push your limits and compete in one of two tracks:
 

--- a/_hackathons/startup-competition.md
+++ b/_hackathons/startup-competition.md
@@ -6,9 +6,9 @@ date: 2025-09-21
 end_date: 2025-12-31
 ---
 
-**Escape The Challenge** is a semester-long Data Science and Entrepreneurship competition co-organized with *theHackLab Bocconi Students*.
+**Escape The Challenge** is a semester-long Data Science and Entrepreneurship competition co-organized with [theHackLab Bocconi Students](https://thehacklab.org/).
 
-Participants presented their solutions to judges from *BCG X* and *Bocconi for Innovation (B4i)*, gaining valuable feedback and insights.
+Participants presented their solutions to judges from [BCG X](https://www.bcg.com/x/) and [Bocconi for Innovation (B4i)](https://www.b4i.unibocconi.it/), gaining valuable feedback and insights.
 
 Push your limits and compete in one of two tracks:
 


### PR DESCRIPTION
This PR fixes missing links to people and organizations in event and hackathon markdown files. After the Jekyll refactoring, some text that should be links (underlined or italicized names) were missing the `href` attributes.

### Changes Made

- Added LinkedIn links to speakers in event pages (Guenda Sciancalepore, Veronica M. Pruinelli, Thomas Mecattaf, Andrea Parodi, Lucabrando Sanfilippo, Saeid Kazemi, Claudia Frosi, Abhinav Pandey)
- Added links to BSML founders (Giacomo Cirò, Giulio Caputi, Alessandro Morosini)
- Added organization links (ION Management Science Lab, SDA Bocconi, Leger Labs, Brightdale)
- Added links to hackathon partners (theHackLab, BCG X, B4i)
- Replaced underlined/italic text without hrefs with proper markdown links
- *[IMPORTANT]* fixed BrightDale's domain name from a non-existent one to the correct one.

### Closes #24 