### PR TITLE
feat: clearer project resources layout

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -17,6 +17,10 @@
   flex-direction: column;
 }
 
+#blog-posts.section {
+  padding-top: 0rem;
+}
+
 .blog-posts article {
   background-color: var(--surface-color);
   box-shadow: 0 4px 25px rgba(102, 0, 204, 0.1);

--- a/assets/css/pages/projects.css
+++ b/assets/css/pages/projects.css
@@ -5,6 +5,11 @@
   padding: 1.5rem 1.75rem;
 }
 
+#dl-starter .section-title {
+  padding-bottom: 1.5rem;
+}
+
+
 #dl-starter .resource-link {
   border: 3px solid #343a40;
   border-radius: 0.75rem;

--- a/assets/css/pages/projects.css
+++ b/assets/css/pages/projects.css
@@ -1,3 +1,39 @@
+#dl-starter .dl-starter-container {
+  --background-color: color-mix(in srgb, var(--default-color), transparent 96%);
+  background-color: var(--background-color);
+  color: var(--default-color); 
+  padding: 1.5rem 1.75rem;
+}
+
+#dl-starter .resource-link {
+  border: 3px solid #343a40;
+  border-radius: 0.75rem;
+  padding: 0.8rem 1.2rem;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: transform 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+#dl-starter .resource-link:hover {
+  transform: scale(1.03);
+  border-color: var(--accent-color);
+  color: var(--accent-color);       
+}
+
+#dl-starter svg {
+  width: 48px;
+  height: 48px;
+  fill: currentColor;
+}
+
+#dl-starter .resource-label {
+  margin-top: 0.4rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
 .project-card .post-meta p {
   margin: 0;
   padding: 0;

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -6,8 +6,8 @@ permalink: /projects/
   
 <section id="dl-starter" class="section">
   <div class="container dl-starter-container">
-    <div class="section-title" data-aos="zoom-out">
-      <h2>Kickstart your Deep Learning project</h2>
+    <div class="section-title" data-aos="zoom-out"">
+      <h2>Kickstart your Machine Learning Project!</h2>
       <p>Core resources to set up your BSML project quickly</p>
     </div>
 
@@ -17,11 +17,8 @@ permalink: /projects/
         <a href="https://github.com/tebe-nigrelli/BS-ML-guide"
            target="_blank"
            class="resource-link">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
-            <path
-              d="M480 576L192 576C139 576 96 533 96 480L96 160C96 107 139 64 192 64L496 64C522.5 64 544 85.5 544 112L544 400C544 420.9 530.6 438.7 512 445.3L512 512C529.7 512 544 526.3 544 544C544 561.7 529.7 576 512 576L480 576zM192 448C174.3 448 160 462.3 160 480C160 497.7 174.3 512 192 512L448 512L448 448L192 448zM224 216C224 229.3 234.7 240 248 240L424 240C437.3 240 448 229.3 448 216C448 202.7 437.3 192 424 192L248 192C234.7 192 224 202.7 224 216zM248 288C234.7 288 224 298.7 224 312C224 325.3 234.7 336 248 336L424 336C437.3 336 448 325.3 448 312C448 298.7 437.3 288 424 288L248 288z" />
-          </svg>
-          <span class="resource-label">Technical project setup guide</span>
+          <i class="bi bi-card-checklist" style="font-size: 2rem;"></i>
+          <span class="resource-label">Technical Project Setup Guide</span>
         </a>
       </div>
 
@@ -30,11 +27,8 @@ permalink: /projects/
         <a href="https://github.com/giacomo-ciro/my-dl-template"
            target="_blank"
            class="resource-link">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
-            <path
-              d="M266.1 392.7C266.1 413.6 255.2 447.8 229.4 447.8C203.6 447.8 192.7 413.6 192.7 392.7C192.7 371.8 203.6 337.6 229.4 337.6C255.2 337.6 266.1 371.8 266.1 392.7zM560 342.2C560 374.1 556.8 407.9 542.5 437.2C504.6 513.8 400.4 512 325.8 512C250 512 139.6 514.7 100.2 437.2C85.6 408.2 80 374.1 80 342.2C80 300.3 93.9 260.7 121.5 228.6C116.3 212.8 113.8 196.2 113.8 179.8C113.8 158.3 118.7 147.5 128.4 128C173.7 128 202.7 137 237.2 164C266.2 157.1 296 154 325.9 154C352.9 154 380.1 156.9 406.3 163.2C440.3 136.5 469.3 128 514.1 128C523.9 147.5 528.7 158.3 528.7 179.8C528.7 196.2 526.1 212.5 521 228C548.5 260.4 560 300.3 560 342.2zM495.7 392.7C495.7 348.8 469 310.1 422.2 310.1C403.3 310.1 385.2 313.5 366.2 316.1C351.3 318.4 336.4 319.3 321.1 319.3C305.9 319.3 291 318.4 276 316.1C257.3 313.5 239 310.1 220 310.1C173.2 310.1 146.5 348.8 146.5 392.7C146.5 480.5 226.9 494 296.9 494L345.1 494C415.4 494 495.7 480.6 495.7 392.7zM413.1 337.6C387.3 337.6 376.4 371.8 376.4 392.7C376.4 413.6 387.3 447.8 413.1 447.8C438.9 447.8 449.8 413.6 449.8 392.7C449.8 371.8 438.9 337.6 413.1 337.6z" />
-          </svg>
-          <span class="resource-label">Ready-to-use GitHub template</span>
+          <i class="bi bi-github" style="font-size: 2rem;"></i>
+          <span class="resource-label">Ready-to-use GitHub Template</span>
         </a>
       </div>
 
@@ -43,11 +37,8 @@ permalink: /projects/
         <a href="https://www.overleaf.com/read/cswbrkgbwhrh#6c992d"
            target="_blank"
            class="resource-link">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
-            <path
-              d="M304 112L192 112C183.2 112 176 119.2 176 128L176 512C176 520.8 183.2 528 192 528L448 528C456.8 528 464 520.8 464 512L464 272L376 272C336.2 272 304 239.8 304 200L304 112zM444.1 224L352 131.9L352 200C352 213.3 362.7 224 376 224L444.1 224zM128 128C128 92.7 156.7 64 192 64L325.5 64C342.5 64 358.8 70.7 370.8 82.7L493.3 205.3C505.3 217.3 512 233.6 512 250.6L512 512C512 547.3 483.3 576 448 576L192 576C156.7 576 128 547.3 128 512L128 128z" />
-          </svg>
-          <span class="resource-label">BSML LaTeX report template</span>
+          <i class="bi bi-file-earmark-text" style="font-size: 2rem;"></i>
+          <span class="resource-label">BSML LaTeX Report Template</span>
         </a>
       </div>
     </div>

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -3,27 +3,56 @@ layout: default
 title: BSML | Projects
 permalink: /projects/
 ---
+  
+<section id="dl-starter" class="section">
+  <div class="container dl-starter-container">
+    <div class="section-title" data-aos="zoom-out">
+      <h2>Kickstart your Deep Learning project</h2>
+      <p>Core resources to set up your BSML project quickly</p>
+    </div>
 
-<div
-  class="page-title container d-flex flex-column justify-content-center align-items-center text-center position-relative"
-  data-aos="zoom-out">
-  <h3>Kickstart your Deep Learning project!</h3>
-  <p>
-    Use our official
-    <a href="https://www.overleaf.com/read/cswbrkgbwhrh#6c992d" target="_blank">BSML LaTeX template</a>
-    to format your report correctly.
-  </p>
-  <p>
-    Follow our  
-    <a href="https://github.com/tebe-nigrelli/BS-ML-guide" target="_blank">Technical Project Setup guideline</a>
-    to set up your project correctly and efficiently.
-  </p>
-  <p>
-    Check out our
-    <a href="https://github.com/giacomo-ciro/my-dl-template.git" target="_blank">ready-to-use GitHub template</a>
-    — a complete code template to help you get started fast.
-  </p>
-</div>
+    <div class="row gy-3 justify-content-center text-center">
+      <!-- 1. Guide -->
+      <div class="col-12 col-sm-6 col-md-4">
+        <a href="https://github.com/tebe-nigrelli/BS-ML-guide"
+           target="_blank"
+           class="resource-link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
+            <path
+              d="M480 576L192 576C139 576 96 533 96 480L96 160C96 107 139 64 192 64L496 64C522.5 64 544 85.5 544 112L544 400C544 420.9 530.6 438.7 512 445.3L512 512C529.7 512 544 526.3 544 544C544 561.7 529.7 576 512 576L480 576zM192 448C174.3 448 160 462.3 160 480C160 497.7 174.3 512 192 512L448 512L448 448L192 448zM224 216C224 229.3 234.7 240 248 240L424 240C437.3 240 448 229.3 448 216C448 202.7 437.3 192 424 192L248 192C234.7 192 224 202.7 224 216zM248 288C234.7 288 224 298.7 224 312C224 325.3 234.7 336 248 336L424 336C437.3 336 448 325.3 448 312C448 298.7 437.3 288 424 288L248 288z" />
+          </svg>
+          <span class="resource-label">Technical project setup guide</span>
+        </a>
+      </div>
+
+      <!-- 2. GitHub template -->
+      <div class="col-12 col-sm-6 col-md-4">
+        <a href="https://github.com/giacomo-ciro/my-dl-template"
+           target="_blank"
+           class="resource-link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
+            <path
+              d="M266.1 392.7C266.1 413.6 255.2 447.8 229.4 447.8C203.6 447.8 192.7 413.6 192.7 392.7C192.7 371.8 203.6 337.6 229.4 337.6C255.2 337.6 266.1 371.8 266.1 392.7zM560 342.2C560 374.1 556.8 407.9 542.5 437.2C504.6 513.8 400.4 512 325.8 512C250 512 139.6 514.7 100.2 437.2C85.6 408.2 80 374.1 80 342.2C80 300.3 93.9 260.7 121.5 228.6C116.3 212.8 113.8 196.2 113.8 179.8C113.8 158.3 118.7 147.5 128.4 128C173.7 128 202.7 137 237.2 164C266.2 157.1 296 154 325.9 154C352.9 154 380.1 156.9 406.3 163.2C440.3 136.5 469.3 128 514.1 128C523.9 147.5 528.7 158.3 528.7 179.8C528.7 196.2 526.1 212.5 521 228C548.5 260.4 560 300.3 560 342.2zM495.7 392.7C495.7 348.8 469 310.1 422.2 310.1C403.3 310.1 385.2 313.5 366.2 316.1C351.3 318.4 336.4 319.3 321.1 319.3C305.9 319.3 291 318.4 276 316.1C257.3 313.5 239 310.1 220 310.1C173.2 310.1 146.5 348.8 146.5 392.7C146.5 480.5 226.9 494 296.9 494L345.1 494C415.4 494 495.7 480.6 495.7 392.7zM413.1 337.6C387.3 337.6 376.4 371.8 376.4 392.7C376.4 413.6 387.3 447.8 413.1 447.8C438.9 447.8 449.8 413.6 449.8 392.7C449.8 371.8 438.9 337.6 413.1 337.6z" />
+          </svg>
+          <span class="resource-label">Ready-to-use GitHub template</span>
+        </a>
+      </div>
+
+      <!-- 3. LaTeX template -->
+      <div class="col-12 col-sm-6 col-md-4">
+        <a href="https://www.overleaf.com/read/cswbrkgbwhrh#6c992d"
+           target="_blank"
+           class="resource-link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
+            <path
+              d="M304 112L192 112C183.2 112 176 119.2 176 128L176 512C176 520.8 183.2 528 192 528L448 528C456.8 528 464 520.8 464 512L464 272L376 272C336.2 272 304 239.8 304 200L304 112zM444.1 224L352 131.9L352 200C352 213.3 362.7 224 376 224L444.1 224zM128 128C128 92.7 156.7 64 192 64L325.5 64C342.5 64 358.8 70.7 370.8 82.7L493.3 205.3C505.3 217.3 512 233.6 512 250.6L512 512C512 547.3 483.3 576 448 576L192 576C156.7 576 128 547.3 128 512L128 128z" />
+          </svg>
+          <span class="resource-label">BSML LaTeX report template</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
 
 <section id="blog-posts" class="blog-posts section">
   <div class="container">


### PR DESCRIPTION
The aim of the commit is to make the starter kit section in `/projects/` stand out by using a more intuitive visual layout with the three reference placed resources side-by-side and the use of svg logos. 

Text has been condensed from the previous state. Hover color, font and and general layout are in line with the rest of the website. 

The svg logos are inserted inline as source code, to avoid importing the _fontawesome_ library or adding more assets to the project. CSS formatting has been added to the relevant assets file.

**NOTE**: in `assets/css/components.css`, top padding is set to zero, otherwise the starter kit component fills the page, hiding the projects.

**NEW**: added the scale-on-hover behavior, with the reasoning that visitors to the page should clearly identify the resource components links as interactive, hence more inviting to click. The whole component is now clickable, as opposed to just the hyperlinks in the text.